### PR TITLE
Fix braced variables

### DIFF
--- a/Syntaxes/Shell-Unix-Bash.tmLanguage
+++ b/Syntaxes/Shell-Unix-Bash.tmLanguage
@@ -1853,6 +1853,18 @@
 							<key>match</key>
 							<string>(\[)([^\]]+)(\])</string>
 						</dict>
+						<dict>
+							<key>include</key>
+							<string>#interpolation</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#string</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#variable</string>
+						</dict>
 					</array>
 				</dict>
 			</array>


### PR DESCRIPTION
Allow interpolation, nested vars and other substitution as per POSIX (IEEE 1003.1 2.6ff). This should fix #15
