### PR TITLE
Apply scope `if-block` only if a line starts with `if`.

### DIFF
--- a/Syntaxes/Shell-Unix-Bash.tmLanguage
+++ b/Syntaxes/Shell-Unix-Bash.tmLanguage
@@ -1441,8 +1441,20 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^\s*(if)\b</string>
-					<key>captures</key>
+					<string>(^|(?&lt;=[&amp;;|]))\s*(if)\b</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.shell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Restrict match to avoid matching in lines like `dd if=/dev/sda1 …`</string>
+					<key>end</key>
+					<string>\b(fi)\b</string>
+					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
@@ -1450,10 +1462,6 @@
 							<string>keyword.control.shell</string>
 						</dict>
 					</dict>
-					<key>comment</key>
-					<string>Restrict match to BOL to avoid matching lines like `dd if=/dev/sda1 …`</string>
-					<key>end</key>
-					<string>\b(fi)\b</string>
 					<key>name</key>
 					<string>meta.scope.if-block.shell</string>
 					<key>patterns</key>


### PR DESCRIPTION
(Leading whitespace is allowed, though.)

This fixes “runaway” scopes for lines like `dd if=/dev/sda1…`.

Runaway scopes are especially a problem if the grammar is embedded in other grammars. For example, in the markdown-redcarpet bundle, if there is a code block triggering a runaway scope, the block’s grammar will extend until EOF, completely messing up the syntax highlight after the end of the code block.
