### PR TITLE
Use tab for “Open directory in Terminal” (optionally).

### DIFF
--- a/Commands/Open directory in Terminal.plist
+++ b/Commands/Open directory in Terminal.plist
@@ -28,6 +28,18 @@ def terminal_script(dir)
 APPLESCRIPT
 end
 
+def terminal_script_new_tab(dir)
+  return &lt;&lt;-APPLESCRIPT
+    tell application "Terminal" to activate
+    tell application "System Events"
+      tell process "Terminal" to keystroke "t" using command down
+    end tell
+    tell application "Terminal"
+      do script "cd #{e_as(e_sh(dir))}; clear; pwd" in the last tab of window 1
+    end tell
+APPLESCRIPT
+end
+
 def iterm_script(dir)
   return &lt;&lt;-APPLESCRIPT
     tell application "iTerm"
@@ -53,22 +65,30 @@ if dir = find_directory
   if ENV['TM_TERMINAL'] =~ /^iterm$/i || is_running('iTerm')
     script = iterm_script(dir)
   else
-    script = terminal_script(dir)
+    script = ENV['TM_TERMINAL_USE_TABS'] ? terminal_script_new_tab(dir) : terminal_script(dir)
   end
   open("|osascript", "w") { |io| io &lt;&lt; script }
 end
 </string>
 	<key>input</key>
 	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>^O</string>
 	<key>name</key>
 	<string>Open Terminal</string>
-	<key>output</key>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
 	<string>discard</string>
 	<key>semanticClass</key>
 	<string>callback.file-browser.action-menu</string>
 	<key>uuid</key>
 	<string>54CDB56E-85EA-11D9-B369-000A95E13C98</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
If `TM_TERMINAL_USE_TABS` is set, the command now creates a new tab in the frontmost terminal window (instead of opening a new terminal window).

Not sure if using an environment variable here is the best way of doing this – I’m open for suggestions!
