### PR TITLE
Enable on Emacs 1st line #... -*- shell-script -*-

### DIFF
--- a/Syntaxes/Shell-Unix-Bash.tmLanguage
+++ b/Syntaxes/Shell-Unix-Bash.tmLanguage
@@ -15,7 +15,7 @@
 		<string>.textmate_init</string>
 	</array>
 	<key>firstLineMatch</key>
-	<string>^#!.*\b(bash|zsh|sh|tcsh)|^#\s*-\*-[^*]*mode:\s*shell-script[^*]*-\*-</string>
+	<string>^#!.*\b(bash|zsh|sh|tcsh)|^#.*-\*-\s*shell-script\s*-\*-|^#\s*-\*-[^*]*mode:\s*shell-script[^*]*-\*-</string>
 	<key>keyEquivalent</key>
 	<string>^~S</string>
 	<key>name</key>


### PR DESCRIPTION
Reason for this patch is that I happened to work with lot of the files marked like that, which is valid way to mark shell scripts for Emacs.

We do not really need to specify `-*- mode: shell-script -*-`, as this used
rather when we want to put also some extra Emacs variables. Also mode comment
can be preceded by anything on 1st line, eg.:

~~~
# bash completion for python                              -*- shell-script -*-
~~~

For more information see: https://www.gnu.org/software/emacs/manual/html_node/emacs/Choosing-Modes.html