### PR TITLE
Add grammar support for bash 4.0

### DIFF
--- a/Syntaxes/Shell-Unix-Bash.tmLanguage
+++ b/Syntaxes/Shell-Unix-Bash.tmLanguage
@@ -1771,7 +1771,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;=^|;|&amp;|\s)(?:alias|bg|bind|break|builtin|caller|cd|command|compgen|complete|dirs|disown|echo|enable|eval|exec|exit|false|fc|fg|getopts|hash|help|history|jobs|kill|let|logout|mapfile|popd|printf|pushd|pwd|read|readonly|set|shift|shopt|source|suspend|test|times|trap|true|type|ulimit|umask|unalias|unset|wait)(?=\s|;|&amp;|$)</string>
+					<string>(?&lt;=^|;|&amp;|\s)(?:alias|bg|bind|break|builtin|caller|cd|command|compgen|complete|dirs|disown|echo|enable|eval|exec|exit|false|fc|fg|getopts|hash|help|history|jobs|kill|let|logout|mapfile|popd|printf|pushd|pwd|read(array)?|readonly|set|shift|shopt|source|suspend|test|times|trap|true|type|ulimit|umask|unalias|unset|wait)(?=\s|;|&amp;|$)</string>
 					<key>name</key>
 					<string>support.function.builtin.shell</string>
 				</dict>

--- a/Syntaxes/Shell-Unix-Bash.tmLanguage
+++ b/Syntaxes/Shell-Unix-Bash.tmLanguage
@@ -1771,7 +1771,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;=^|;|&amp;|\s)(?:alias|bg|bind|break|builtin|caller|cd|command|compgen|complete|dirs|disown|echo|enable|eval|exec|exit|false|fc|fg|getopts|hash|help|history|jobs|kill|let|logout|popd|printf|pushd|pwd|read|readonly|set|shift|shopt|source|suspend|test|times|trap|true|type|ulimit|umask|unalias|unset|wait)(?=\s|;|&amp;|$)</string>
+					<string>(?&lt;=^|;|&amp;|\s)(?:alias|bg|bind|break|builtin|caller|cd|command|compgen|complete|dirs|disown|echo|enable|eval|exec|exit|false|fc|fg|getopts|hash|help|history|jobs|kill|let|logout|mapfile|popd|printf|pushd|pwd|read|readonly|set|shift|shopt|source|suspend|test|times|trap|true|type|ulimit|umask|unalias|unset|wait)(?=\s|;|&amp;|$)</string>
 					<key>name</key>
 					<string>support.function.builtin.shell</string>
 				</dict>

--- a/Syntaxes/Shell-Unix-Bash.tmLanguage
+++ b/Syntaxes/Shell-Unix-Bash.tmLanguage
@@ -1219,7 +1219,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;=^|;|&amp;|\s)(?:if|then|else|elif|fi|for|in|do|done|select|case|continue|esac|while|until|return)(?=\s|;|&amp;|$)</string>
+					<string>(?&lt;=^|;|&amp;|\s)(?:if|then|else|elif|fi|for|in|do|done|select|case|continue|esac|while|until|return|coproc)(?=\s|;|&amp;|$)</string>
 					<key>name</key>
 					<string>keyword.control.shell</string>
 				</dict>


### PR DESCRIPTION
Bash 4.0 introduced [coprocesses](https://www.gnu.org/software/bash/manual/html_node/Coprocesses.html#Coprocesses) — a way to execute commands asynchronously in a subshell.  They are also available in [zsh](http://zsh.sourceforge.net/Doc/Release/Shell-Grammar.html#Simple-Commands-_0026-Pipelines).

I added the `coproc` reserved word to the grammar as a `keyword` — specifically a `keyword.control.shell`. This seemed like the logical choice as it is more of a reserved word than a builtin function.

It could be given its own scope, but it *should* be used with braces, which would create a `meta.scope.group.shell` scope:

```sh
coproc mycoproc { cmd; }
```