### PR TITLE
Improve open directory in tab

### DIFF
--- a/Commands/Open directory in Terminal.plist
+++ b/Commands/Open directory in Terminal.plist
@@ -32,12 +32,20 @@ def terminal_script_new_tab(dir)
   return &lt;&lt;-APPLESCRIPT
   tell application "Terminal"
     activate
+    set numberOfTabs to count tabs in window 1
     tell application "System Events"
       repeat while "Terminal" is not name of (process 1 where frontmost is true)
         delay 0.1
       end repeat
       tell process "Terminal" to keystroke "t" using command down
     end tell
+    set startedAt to current date
+    repeat while (count tabs in window 1) is numberOfTabs
+      delay 0.1
+      if (current date) - startedAt > 2 then
+        error "Could not open new tab"
+      end if
+    end repeat
     do script "cd #{e_as(e_sh(dir))}; clear; pwd" in the last tab of window 1
   end tell
 APPLESCRIPT

--- a/Commands/Open directory in Terminal.plist
+++ b/Commands/Open directory in Terminal.plist
@@ -31,14 +31,14 @@ end
 def terminal_script_new_tab(dir)
   return &lt;&lt;-APPLESCRIPT
   tell application "Terminal"
-  	activate
-  	tell application "System Events"
-  		repeat while "Terminal" is not name of (process 1 where frontmost is true)
-  			delay 0.1
-  		end repeat
-  		tell process "Terminal" to keystroke "t" using command down
-  	end tell
-  	do script "cd #{e_as(e_sh(dir))}; clear; pwd" in the last tab of window 1
+    activate
+    tell application "System Events"
+      repeat while "Terminal" is not name of (process 1 where frontmost is true)
+        delay 0.1
+      end repeat
+      tell process "Terminal" to keystroke "t" using command down
+    end tell
+    do script "cd #{e_as(e_sh(dir))}; clear; pwd" in the last tab of window 1
   end tell
 APPLESCRIPT
 end


### PR DESCRIPTION
Wait until the number of tabs in the terminal application has changed before executing the shell command. Abort after 2 seconds, if no new tab seems to have appeared.

This fixes a race condition where the new tab was opened but the shell command was still run in the previous open tab.

It does not fix the problem with the user not releasing the modifier keys used to initiate the command, though (see 32af606). But if this happens, we now at least do not try to run the shell command in an existing tab.