### PR TITLE
Restrict “Documentation for Word” to `source.shell`

### DIFF
--- a/Commands/man.plist
+++ b/Commands/man.plist
@@ -45,6 +45,8 @@ echo "Couldn’t find documentation for “${word}”"
 	<string>text</string>
 	<key>outputLocation</key>
 	<string>toolTip</string>
+	<key>scope</key>
+	<string>source.shell</string>
 	<key>semanticClass</key>
 	<string>lookup.define.shell</string>
 	<key>uuid</key>


### PR DESCRIPTION
Is this command really meant to be globally available?