### PR TITLE
Fix “Run in Terminal” for macOS High Sierra

### DIFF
--- a/Commands/Open directory in Terminal.plist
+++ b/Commands/Open directory in Terminal.plist
@@ -32,7 +32,7 @@ def terminal_script_new_tab(dir)
   return &lt;&lt;-APPLESCRIPT
   tell application "Terminal"
     activate
-    set numberOfTabs to count tabs in window 1
+    set originalContent to contents of tab in window 1
     tell application "System Events"
       repeat while "Terminal" is not name of (process 1 where frontmost is true)
         delay 0.1
@@ -40,9 +40,9 @@ def terminal_script_new_tab(dir)
       tell process "Terminal" to keystroke "t" using command down
     end tell
     set startedAt to current date
-    repeat while (count tabs in window 1) is numberOfTabs
+    repeat while (contents of tab in window 1) is originalContent
       delay 0.1
-      if (current date) - startedAt > 2 then
+      if (current date) - startedAt &gt; 2 then
         error "Could not open new tab"
       end if
     end repeat


### PR DESCRIPTION
It seems that in High Sierra, `count tabs` for the Terminal app always returns 1 (probably a bug?). So this can no longer be used for checking if the new tab is ready.

Instead we now wait until the content of the visible tab has changed, which seems to work fine