### PR TITLE
Add .zprofile to fileTypes

### DIFF
--- a/Syntaxes/Shell-Unix-Bash.tmLanguage
+++ b/Syntaxes/Shell-Unix-Bash.tmLanguage
@@ -13,6 +13,7 @@
 		<string>profile</string>
 		<string>bash_logout</string>
 		<string>.textmate_init</string>
+		<string>zprofile</string>
 	</array>
 	<key>firstLineMatch</key>
 	<string>^#!.*\b(bash|zsh|sh|tcsh)|^#.*-\*-.*\bshell-script\b.*-\*-</string>


### PR DESCRIPTION
Add support for fileType `.zprofile`. zsh is the default shell of macos since Catalina…